### PR TITLE
remove #tag-stuff include

### DIFF
--- a/Syntaxes/Mediawiki.tmLanguage
+++ b/Syntaxes/Mediawiki.tmLanguage
@@ -145,15 +145,6 @@
 							<string>punctuation.definition.tag.mediawiki</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>meta.tag.source.mediawiki</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#tag-stuff</string>
-						</dict>
-					</array>
 				</dict>
 				<dict>
 					<key>captures</key>


### PR DESCRIPTION
This include is referencing something which is not defined in the
`<key>repository</key>` section of the file. This causes it to fail validation
when e.g. converting from the tmLanguage file to a .sublime-syntax file.

I think removing it should be harmless given it is referencing something
non-existent anyway.